### PR TITLE
Fix stale VEB_INSTALL_DIR in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This is a template project for creating VillageSQL extensions. It provides the m
 
 - **Build**: `cmake . && make` (or `mkdir build && cd build && cmake .. && make`)
 - **Create VEB package**: Automatically created during `make`
-- **Install extension**: `make install` (if VEB_INSTALL_DIR is defined)
+- **Install extension**: `make install` (if VillageSQL_VEB_INSTALL_DIR is defined)
 
 The build process:
 1. Uses CMake to find VillageSQL via `find_package(VillageSQL REQUIRED)`


### PR DESCRIPTION
Follow-up to PR #7 (closes #6). Renames bare VEB_INSTALL_DIR to VillageSQL_VEB_INSTALL_DIR to match the canonical CMake variable name used in FindVillageSQL.cmake.

Affects AGENTS.md (symlinked as CLAUDE.md).

AI=CLAUDE