### PR TITLE
Update template to typed C++ API (vsql.h)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,16 +50,18 @@ Set `VillageSQL_BUILD_DIR` to point to your VillageSQL build directory.
 
 VEF has two protocols:
 
-- **Protocol 2 (current)** — typed C++ API. Include `<villagesql/vsql.h>`,
+- **Protocol 2 (in development)** — typed C++ API. Include `<villagesql/vsql.h>`,
   `using namespace vsql;`. Functions use typed wrappers (`IntArg`, `StringResult`,
-  etc.) instead of raw pointers. This template uses Protocol 2.
-- **Protocol 1 (legacy)** — raw ABI. Include `<villagesql/extension.h>`,
+  etc.) instead of raw pointers. Not yet available in the public SDK — `vsql.h`
+  is still being finalized in the server.
+- **Protocol 1 (current)** — raw ABI. Include `<villagesql/extension.h>`,
   `using namespace villagesql::extension_builder; using namespace villagesql::func_builder;`.
   Functions take `vef_context_t*` and `vef_vdf_result_t*` parameters directly.
+  This template uses Protocol 1.
 
-Use Protocol 2 for all new extensions. If you encounter documentation or examples
-using `extension.h` or `vef_context_t*`, those are Protocol 1 — do not mix the two
-in the same extension.
+Use Protocol 1 for all new extensions until Protocol 2 ships. When Protocol 2 is
+available, `vsql.h` will be in the public SDK `include/` directory and this template
+will be updated. Do not mix the two protocols in the same extension.
 
 Functions are registered using the `VEF_GENERATE_ENTRY_POINTS()` macro with a fluent builder interface.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,37 +52,40 @@ VEF provides a modern C++ API for creating extensions. Functions are registered 
 
 ### Basic Function Implementation
 
-Each function is implemented as a single function that takes context and result parameters:
+Each function uses typed wrapper parameters — no raw ABI types needed:
 
 ```cpp
-#include <villagesql/extension.h>
+#include <villagesql/vsql.h>
 
-using namespace villagesql::extension_builder;
-using namespace villagesql::func_builder;
+#include <cstring>
 
-// Function implementation
-void my_function_impl(vef_context_t* ctx, vef_vdf_result_t* result) {
-    // Implement function logic
-    // Set result->type (IS_VALUE, IS_NULL, IS_ERROR)
-    // For strings: copy to result->str_buf, set result->actual_len
-    // For integers: set result->int_value
-    // For binary: copy to result->bin_buf, set result->actual_len
+using namespace vsql;
+
+// Integer result (no args)
+void my_function_impl(IntResult out) {
+    out.set(42);
+}
+
+// String result: write into buffer(), then call set_length()
+void my_string_impl(StringResult out) {
+    const char* value = "result";
+    auto buf = out.buffer();
+    memcpy(buf.data(), value, strlen(value));
+    out.set_length(strlen(value));
 }
 ```
 
 ### Function with Arguments
 
-For functions with arguments, add `vef_invalue_t*` parameters:
+Typed input wrappers (`IntArg`, `RealArg`, `StringArg`, `CustomArg`) provide
+`is_null()` and `value()`. List args before the result parameter:
 
 ```cpp
-void my_function_impl(vef_context_t* ctx,
-                      vef_invalue_t* arg1,
-                      vef_invalue_t* arg2,
-                      vef_vdf_result_t* result) {
-    // Check for NULL: arg1->is_null
-    // Access string: arg1->str_value, arg1->str_len
-    // Access integer: arg1->int_value
-    // Access binary: arg1->bin_value, arg1->bin_len
+void my_function_impl(IntArg arg1, StringArg arg2, IntResult out) {
+    if (arg1.is_null() || arg2.is_null()) { out.set_null(); return; }
+    // arg1.value() -> int64_t
+    // arg2.value() -> std::string_view
+    out.set(arg1.value());
 }
 ```
 
@@ -103,9 +106,12 @@ VEF_GENERATE_ENTRY_POINTS(
 
 ### Result Types
 
-- `IS_VALUE` - Function returned a value
-- `IS_NULL` - Function returned NULL
-- `IS_ERROR` - Function encountered an error (set `result->error_msg`)
+Call the typed wrapper method on the result parameter:
+
+- `out.set(value)` / `out.set_length(n)` — returns a value (`VEF_RESULT_VALUE`)
+- `out.set_null()` — returns SQL NULL
+- `out.warning(msg)` — returns NULL and adds a SQL warning
+- `out.error(msg)` — aborts statement execution with an error
 
 ## Testing
 
@@ -203,7 +209,7 @@ When creating new source files, always include this copyright block before any c
 When asked to add functionality to this template:
 
 1. **Adding a new function**:
-   - Create implementation function with signature: `void func_impl(vef_context_t* ctx, [args...], vef_vdf_result_t* result)`
+   - Create implementation function with typed wrappers: `void func_impl(IntArg a, StringResult out)` (args first, result last)
    - Add function to `VEF_GENERATE_ENTRY_POINTS()` block using `.func(make_func<&func_impl>("name")...)`
    - Specify return type, parameters, and buffer size
    - Add to CMakeLists.txt if creating new source file
@@ -230,4 +236,4 @@ When asked to add functionality to this template:
 - Always include proper copyright headers in source files
 - Use C++17 standard
 - Functions are registered in code using VEF API (no install.sql needed)
-- Result types: IS_VALUE, IS_NULL, IS_ERROR
+- Result: call `out.set(v)`, `out.set_null()`, `out.warning(msg)`, or `out.error(msg)`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,20 @@ Set `VillageSQL_BUILD_DIR` to point to your VillageSQL build directory.
 
 ## VillageSQL Extension Framework (VEF) API Pattern
 
-VEF provides a modern C++ API for creating extensions. Functions are registered using the `VEF_GENERATE_ENTRY_POINTS()` macro with a fluent builder interface.
+VEF has two protocols:
+
+- **Protocol 2 (current)** — typed C++ API. Include `<villagesql/vsql.h>`,
+  `using namespace vsql;`. Functions use typed wrappers (`IntArg`, `StringResult`,
+  etc.) instead of raw pointers. This template uses Protocol 2.
+- **Protocol 1 (legacy)** — raw ABI. Include `<villagesql/extension.h>`,
+  `using namespace villagesql::extension_builder; using namespace villagesql::func_builder;`.
+  Functions take `vef_context_t*` and `vef_vdf_result_t*` parameters directly.
+
+Use Protocol 2 for all new extensions. If you encounter documentation or examples
+using `extension.h` or `vef_context_t*`, those are Protocol 1 — do not mix the two
+in the same extension.
+
+Functions are registered using the `VEF_GENERATE_ENTRY_POINTS()` macro with a fluent builder interface.
 
 ### Basic Function Implementation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ Call the typed wrapper method on the result parameter:
 
 - `out.set(value)` / `out.set_length(n)` — returns a value (`VEF_RESULT_VALUE`)
 - `out.set_null()` — returns SQL NULL
-- `out.warning(msg)` — returns NULL and adds a SQL warning
+- `out.warning(msg)` — returns NULL with a SQL warning; call instead of `out.set()`, not in addition to it
 - `out.error(msg)` — aborts statement execution with an error
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ To create your own extension:
 
 3. **Implement Your Functions**:
    - Modify `src/hello.cc` or create new source files
-   - Use the VDF API signature: `void func_impl(vef_context_t* ctx, [args...], vef_vdf_result_t* result)`
+   - Use typed wrapper parameters: `IntArg`, `RealArg`, `StringArg`, `StringResult`, etc.
    - Register functions using `VEF_GENERATE_ENTRY_POINTS()` macro
-   - Include `<villagesql/extension.h>`
+   - Include `<villagesql/vsql.h>`
 
 4. **Create Tests**:
    - Add `.test` files in the `mysql-test/t/` directory

--- a/src/hello.cc
+++ b/src/hello.cc
@@ -14,18 +14,19 @@
  * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <villagesql/vsql.h>
+#include <villagesql/extension.h>
 
 #include <cstring>
 
-using namespace vsql;
+using namespace villagesql::extension_builder;
+using namespace villagesql::func_builder;
 
 // Hello world function implementation
-void hello_world_impl(StringResult out) {
+void hello_world_impl(vef_context_t* ctx, vef_vdf_result_t* result) {
   const char* hello = "Hello, World!";
-  auto buf = out.buffer();
-  memcpy(buf.data(), hello, strlen(hello));
-  out.set_length(strlen(hello));
+  strcpy(result->str_buf, hello);
+  result->type = VEF_RESULT_VALUE;
+  result->actual_len = strlen(hello);
 }
 
 // Extension registration

--- a/src/hello.cc
+++ b/src/hello.cc
@@ -14,19 +14,18 @@
  * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <villagesql/extension.h>
+#include <villagesql/vsql.h>
 
 #include <cstring>
 
-using namespace villagesql::extension_builder;
-using namespace villagesql::func_builder;
+using namespace vsql;
 
 // Hello world function implementation
-void hello_world_impl(vef_context_t* ctx, vef_vdf_result_t* result) {
+void hello_world_impl(StringResult out) {
   const char* hello = "Hello, World!";
-  strcpy(result->str_buf, hello);
-  result->type = VEF_RESULT_VALUE;
-  result->actual_len = strlen(hello);
+  auto buf = out.buffer();
+  memcpy(buf.data(), hello, strlen(hello));
+  out.set_length(strlen(hello));
 }
 
 // Extension registration


### PR DESCRIPTION
 ## Summary                                                                                                          
  - `src/hello.cc`: replace V1 raw ABI (extension.h, vef_context_t*)                                                    
    with typed API (vsql.h, StringResult); function is now zero-boilerplate                                             
    (villagesql-server@85218c53f42)                                                                                     
  - `README.md`: update include guidance and VDF signature description                                                  
    to match typed API entry point (villagesql-server@85218c53f42)                                                      
  - `AGENTS.md`: replace V1 raw ABI examples with typed API; add                                                        
    Protocol 1 vs 2 context so agents know extension.h is legacy                                                        
    (villagesql-server@85218c53f42)                                                                                     
                                                                                                                        
  ## Aligns to                                                                                                          
  villagesql-server@85218c53f42 — V1/V2 API split; vsql.h is the recommended header for typed C++ extensions          
                                                                                                                                                                                                                                                
  AI=CLAUDE           