### PR TITLE
Use no-arg make_extension()

### DIFF
--- a/src/hello.cc
+++ b/src/hello.cc
@@ -31,7 +31,7 @@ void hello_world_impl(vef_context_t* ctx, vef_vdf_result_t* result) {
 
 // Extension registration
 VEF_GENERATE_ENTRY_POINTS(
-  make_extension("vsql_extension_template", "1.0.0")
+  make_extension()
     .func(make_func<&hello_world_impl>("hello_world")
       .returns(STRING)
       .buffer_size(14)  // "Hello, World!" + null terminator

--- a/src/hello.cc
+++ b/src/hello.cc
@@ -14,19 +14,18 @@
  * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <villagesql/extension.h>
+#include <villagesql/vsql.h>
 
 #include <cstring>
 
-using namespace villagesql::extension_builder;
-using namespace villagesql::func_builder;
+using namespace vsql;
 
 // Hello world function implementation
-void hello_world_impl(vef_context_t* ctx, vef_vdf_result_t* result) {
+void hello_world_impl(StringResult out) {
   const char* hello = "Hello, World!";
-  strcpy(result->str_buf, hello);
-  result->type = VEF_RESULT_VALUE;
-  result->actual_len = strlen(hello);
+  auto buf = out.buffer();
+  memcpy(buf.data(), hello, strlen(hello));
+  out.set_length(strlen(hello));
 }
 
 // Extension registration


### PR DESCRIPTION
Name and version now come from manifest.json.
The two-arg form still compiles but is deprecated.

AI=CLAUDE